### PR TITLE
Fix minor bugs

### DIFF
--- a/modules/tasks/tasks.class.php
+++ b/modules/tasks/tasks.class.php
@@ -637,7 +637,7 @@ class CTask extends CDpObject
 			$ret = db_insertObject('tasks', $this, 'task_id');
 			addHistory('tasks', $this->task_id, 'add', $this->task_name, $this->task_project);
 
-			if (!empty($this->task_parent)) {  // should avoid throwing a warning (gwyneth 20210425)
+			if (empty($this->task_parent)) {  // should avoid throwing a warning (gwyneth 20210425)
 				$q->addTable('tasks');
 				$q->addUpdate('task_parent', $this->task_id);
 				$q->addWhere('task_id = ' . $this->task_id);

--- a/style/default/css/overrides.css
+++ b/style/default/css/overrides.css
@@ -35,3 +35,8 @@
 .ql-align-justify {
   text-align: justify;
 }
+
+.ql-toolbar,
+.ql-container {
+    background: #ffffff;
+}


### PR DESCRIPTION
This fixes two minor bugs:

- When creating a task, `task_parent` wouldn't save correctly because you had changed a `if (!$this->task_parent)` to `if(!empty($this->task_parent)`, which completely inverts the meaning. I changed it to `if (empty($this->task_parent)`, and it started working correctly again. This only appears to have affected new tasks, not edited ones.
- There was no background color set on the WYSIWYG field; I suppose this is a preference thing, but I found it hard to read against the blue background, so I made it white.